### PR TITLE
feat: Add new status error pattern

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -11,22 +11,32 @@ import (
 )
 
 // Status is the type used to represent error types
+//
+// Deprecated: This layer of abstraction provided more overhead than value.
+// When using the new status error API, the HTTP status codes should be used
+// directly.
 type Status int
 
 // The error type constants for errors relating to a particular status.
 const (
 	_ Status = iota
 	// InvalidFormat represents badly formatted input errors.
+	// Deprecated: Use http.StatusBadRequest
 	InvalidFormat
 	// Forbidden represents errors where the action is not allowed.
+	// Deprecated: Use http.StatusForbidden
 	Forbidden
 	// NotFound represents missing or unauthorized data errors.
+	// Deprecated: Use http.StatusNotFound
 	NotFound
 	// Conflict represents errors from a conflicting application state.
+	// Deprecated: Use http.StatusConflict
 	Conflict
 	// Internal represents bugs in the application.
+	// Deprecated: Use http.StatusInternalServerError
 	Internal
 	// NoAuth represents errors where the request is missing authentication information
+	// Deprecated: Use http.StatusUnauthorized
 	NoAuth
 )
 
@@ -52,6 +62,11 @@ func (s Status) String() string {
 // StatusError attaches a status to an error. This is used to differentiate between different kinds of failures:
 // those caused by badly formatted input, those caused by requests for missing or unauthorized data, and those
 // caused by bugs in the code
+//
+// Deprecated: The lack of stack-trace information, overhead of serrors-
+// specific statuses, and requirement to use a struct type rather than
+// interface with errors.Is and errors.As made this difficult to use. Instead,
+// prefer NewStatusError or WithStatus for constructing new errors.
 type StatusError struct {
 	Status Status
 	Err    error
@@ -146,7 +161,7 @@ func New(msg string) error {
 func Errorf(format string, vals ...interface{}) error {
 	err := fmt.Errorf(format, vals...)
 	// it's possible that there was already a StackTracer in the unwrap chain in the fmt.Errorf.
-	// if so, use that stacktracker in the StackErr.
+	// if so, use that stacktracer in the StackErr.
 	var st StackTracer
 	if errors.As(err, &st) {
 		return StackErr{

--- a/status.go
+++ b/status.go
@@ -1,0 +1,115 @@
+package serrors
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+// StatusCoder represents something that returns a status code.
+type StatusCoder interface {
+	StatusCode() int
+}
+
+type statusError struct {
+	HTTPStatusCode int
+	Err            error
+}
+
+var _ StatusCoder = statusError{}
+
+// NewStatusError returns an error that bundles an HTTP status code. The stack
+// trace will be captured.
+func NewStatusError(code int, msg string) error {
+	return statusError{
+		HTTPStatusCode: code,
+		Err: &StackErr{
+			Err:   errors.New(msg),
+			trace: buildStackTrace(),
+		},
+	}
+}
+
+// NewStatusErrorf returns an error that bundles an HTTP status code, sharing
+// fmt.Errorf semantics. The stack trace will be captured if not already
+// present.
+func NewStatusErrorf(code int, format string, a ...interface{}) error {
+	err := fmt.Errorf(format, a...)
+
+	// it's possible that there was already a StackTracer in the unwrap chain in the fmt.Errorf.
+	// if so, use that stacktracer in the StackErr.
+	var st StackTracer
+	if errors.As(err, &st) {
+		return statusError{
+			HTTPStatusCode: code,
+			Err: &StackErr{
+				Err:         err,
+				stackTracer: st,
+			},
+		}
+	}
+
+	return statusError{
+		HTTPStatusCode: code,
+		Err: &StackErr{
+			Err:   err,
+			trace: buildStackTrace(),
+		},
+	}
+}
+
+// WithStatus bundles an error with an HTTP status code. The stack trace will
+// be captured if not already present.
+func WithStatus(code int, err error) error {
+	if err == nil {
+		panic("cannot attach status to nil error")
+	}
+
+	var se StackTracer
+	if errors.As(err, &se) {
+		return statusError{
+			HTTPStatusCode: code,
+			Err:            err,
+		}
+	}
+
+	return statusError{
+		HTTPStatusCode: code,
+		Err: &StackErr{
+			Err:   err,
+			trace: buildStackTrace(),
+		},
+	}
+}
+
+// Error returns the underlying error as a string. Status code information
+// will not be captured.
+func (s statusError) Error() string {
+	if s.Err == nil {
+		return ""
+	}
+	return s.Err.Error()
+}
+
+// Format uses the underlying formatter for the error, if one exists. This
+// allows us to preserve the behavior of the underlying error if the verb
+// changes the way it is formatted.
+func (s statusError) Format(f fmt.State, verb rune) {
+	var formatter fmt.Formatter
+	if errors.As(s.Err, &formatter) {
+		formatter.Format(f, verb)
+		return
+	}
+
+	io.WriteString(f, s.Error()) // nolint: errcheck
+}
+
+// Unwrap returns the underlying error.
+func (s statusError) Unwrap() error {
+	return s.Err
+}
+
+// StatusCode returns the HTTP status code captured when the error was created.
+func (s statusError) StatusCode() int {
+	return s.HTTPStatusCode
+}

--- a/status_test.go
+++ b/status_test.go
@@ -1,0 +1,133 @@
+package serrors_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/morningconsult/serrors"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewStatusError(t *testing.T) {
+	code := 400
+	err := serrors.NewStatusError(code, "oh no")
+
+	var sc serrors.StatusCoder
+	if !errors.As(err, &sc) {
+		t.Fatal("err is not a StatusCoder")
+	}
+
+	if got := sc.StatusCode(); got != code {
+		t.Errorf("want code %d, got %d", code, got)
+	}
+}
+
+func TestNewStatusErrorf(t *testing.T) {
+	code := 400
+	err := serrors.NewStatusErrorf(code, "foo: %s", "bar")
+
+	var sc serrors.StatusCoder
+	if !errors.As(err, &sc) {
+		t.Fatal("err is not a StatusCoder")
+	}
+
+	if got := sc.StatusCode(); got != code {
+		t.Errorf("want code %d, got %d", code, got)
+	}
+
+	wantMsg := "foo: bar"
+	if msg := err.Error(); msg != wantMsg {
+		t.Errorf("want message %q, got %q", wantMsg, msg)
+	}
+}
+
+func TestNewStatusErrorf_wraps_stack_tracer(t *testing.T) {
+	code := 400
+
+	err := serrors.New("oh no")
+	err = serrors.NewStatusErrorf(code, "wrapping: %w", err)
+
+	var sc serrors.StatusCoder
+	if !errors.As(err, &sc) {
+		t.Fatal("err is not a StatusCoder")
+	}
+
+	if got := sc.StatusCode(); got != code {
+		t.Errorf("want code %d, got %d", code, got)
+	}
+
+	wantMsg := "wrapping: oh no"
+	if msg := err.Error(); msg != wantMsg {
+		t.Errorf("want message %q, got %q", wantMsg, msg)
+	}
+
+	wantVerbose := `wrapping: oh no
+github.com/morningconsult/serrors_test.TestNewStatusErrorf_wraps_stack_tracer (github.com/morningconsult/serrors_test/status_test.go:49)
+testing.tRunner (testing/testing.go:909)
+runtime.goexit (runtime/asm_amd64.s:1357)`
+	got := fmt.Sprintf("%+v", err)
+	if diff := cmp.Diff(wantVerbose, got); diff != "" {
+		t.Errorf("results differ (-want +got):\n%s", diff)
+	}
+}
+
+func TestWithStatus(t *testing.T) {
+	err := serrors.New("test message")
+	err = serrors.WithStatus(200, err)
+
+	expected := `test message
+github.com/morningconsult/serrors_test.TestWithStatus (github.com/morningconsult/serrors_test/status_test.go:77)
+testing.tRunner (testing/testing.go:909)
+runtime.goexit (runtime/asm_amd64.s:1357)`
+	result := fmt.Sprintf("%+v", err)
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("results differ (-want +got):\n%s", diff)
+	}
+}
+
+func TestWithStatus_nil(t *testing.T) {
+	defer func() {
+		wantPanic := "cannot attach status to nil error"
+		if r := recover(); r == nil || r != wantPanic {
+			t.Errorf("want panic %q, got %q", wantPanic, r)
+		}
+	}()
+	serrors.WithStatus(200, nil) // nolint: errcheck
+}
+
+type messageError struct{}
+
+func (e messageError) Error() string {
+	return "foo"
+}
+
+func Test_statusError_Format(t *testing.T) {
+	err := serrors.WithStatus(400, messageError{})
+
+	want := "foo"
+	got := fmt.Sprintf("%s", err)
+	if want != got {
+		t.Errorf("want message %q, got %q", want, got)
+	}
+}
+
+func Test_statusError_Is(t *testing.T) {
+	err := errors.New("oh boy")
+	err400 := serrors.WithStatus(400, err)
+
+	if !errors.Is(err400, err400) {
+		t.Error("error does not equal itself")
+	}
+
+	err500 := serrors.WithStatus(500, err)
+	if errors.Is(err400, err500) {
+		t.Error("status codes were not compared")
+	}
+
+	wrapped := fmt.Errorf("wrapped: %w", err400)
+	if !errors.Is(wrapped, err400) {
+		t.Error("not equal to wrapped version")
+	}
+}


### PR DESCRIPTION
The StatusError type is difficult to work with, and forces a “viral”
dependency, in that the only way to check the error is to use the
package.

As a general redesign of the pattern, the following changes are
proposed:

- A new status error type should be created to allow for the new error
  handling patterns without breaking existing code. We can simply
  deprecate the existing `StatusError` type for removal in a future
  version.
- The StatusCode field should be a method, so we can check for statuses
  using interfaces rather than requiring the struct type, so you can
  check for the error without importing the library, if desired.
- The new type should only be creatable through a constructor. This
  allows us to create status errors with a stack trace by default,
  rather than through manual orchestration.
- The new status error type should be unexported, since its relevant
  functionality is only accessible through methods, and functions that
  return them already return an `error` type.
- The status error type should only use http status codes, which avoids
  a translation layer.

This introduces the following new constructors:

- `serrors.WithStatus` takes an existing and attaches a status code.
- `serrors.NewStatusError` creates a new error from a string.
- `serrors.NewStatusErrorf` creates an error with `fmt.Errorf` semantics.

And while not strictly required, the following interface for
convenience:

- `serrors.StatusCoder` represents anything that returns a status code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.