### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies


### PR DESCRIPTION
This adds dependabot to the project. While we likely will not be needing continual updates, this is an added layer of checking off boxes for being able to say we are continously checking for security dependencies and such.

I used the default Github "add new configuration" here because this project is so simple.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.