### PR TITLE
feat: Add NewFromStatus

### DIFF
--- a/status.go
+++ b/status.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 )
 
 // StatusCoder represents something that returns a status code.
@@ -77,6 +78,23 @@ func WithStatus(code int, err error) error {
 		HTTPStatusCode: code,
 		Err: &StackErr{
 			Err:   err,
+			trace: buildStackTrace(),
+		},
+	}
+}
+
+// NewFromStatus creates a new StatusError with the given status code and the
+// HTTP status text from the standard library.
+func NewFromStatus(code int) error {
+	msg := http.StatusText(code)
+	if msg == "" {
+		msg = "Unknown Status Error"
+	}
+
+	return statusError{
+		HTTPStatusCode: code,
+		Err: &StackErr{
+			Err:   errors.New(msg),
 			trace: buildStackTrace(),
 		},
 	}


### PR DESCRIPTION
This is based on a pattern that I've found quite common, both in writing
and reviewing code, where there is a desire to create a new status error
containing no information other than the HTTP status code and its text.
Because the standard library has status text built in, a typical manual
execution might look like this:

    serrors.NewStatusError(
    	http.StatusNotFound,
    	http.StatusText(http.StatusNotFound),
    )

Because this is tedious, the proposal is to have a more direct option:

    serrors.NewFromStatus(http.StatusNotFound)

There is one caveat to this implementation, which is that an idiomatic
error in Go does not start with a capital letter, while the HTTP status
texts are title case. While we could make a call to `strings.ToLower`,
the problem is that many of the statuses such as "OK", "HTTP Version Not
Supported", or "I'm a teapot" would produce incorrect messages. My take
is that the most correct behavior would be to manually correct the case
for every status, or just leave the error messages as is. I opted for
the lazier solution, but it would not be hard to convince me otherwise.

Note that this changeset is a proposal, and should be evaluated under
the assumption that the correct path forward might be to reject it.

Signed-off-by: Rob Liebowitz <rliebowitz@morningconsult.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.