### PR TITLE
feat!: remove custom error Format function

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"runtime"
-	"strings"
 	"text/template"
 )
 
@@ -112,26 +110,6 @@ func (se stackErr) Error() string {
 		return ""
 	}
 	return se.err.Error()
-}
-
-// Format controls the optional display of the stack trace. Use %+v to output the stack trace, use %v or %s to output
-// the wrapped error only, use %q to get a single-quoted character literal safely escaped with Go syntax for the wrapped
-// error.
-func (se stackErr) Format(s fmt.State, verb rune) {
-	switch verb {
-	case 'v':
-		if s.Flag('+') {
-			fmt.Fprintf(s, "%+v\n", se.Unwrap())
-			trace, _ := Trace(se, PanicFormat)
-			io.WriteString(s, strings.Join(trace, "\n")) //nolint:errcheck
-			return
-		}
-		io.WriteString(s, se.Error()) //nolint:errcheck
-	case 's':
-		io.WriteString(s, se.Error()) //nolint:errcheck
-	case 'q':
-		fmt.Fprintf(s, "%q", se.Error())
-	}
 }
 
 // StandardFormat is a one-line template used to convert a *runtime.Frame to a

--- a/errors_test.go
+++ b/errors_test.go
@@ -2,7 +2,6 @@ package serrors_test
 
 import (
 	"errors"
-	"fmt"
 	"runtime"
 	"strings"
 	"testing"
@@ -15,62 +14,16 @@ import (
 func Test_stackErr(t *testing.T) {
 	e := serrors.New("new err")
 	se := serrors.WithStack(e)
-	data := []struct {
-		name         string
-		formatString string
-		expected     string
-	}{
-		{
-			name:         "string",
-			formatString: "%s",
-			expected:     "new err",
-		},
-		{
-			name:         "quoted",
-			formatString: "%q",
-			expected:     `"new err"`,
-		},
-		{
-			name:         "value",
-			formatString: "%v",
-			expected:     "new err",
-		},
-		{
-			name:         "detailed value",
-			formatString: "%+v",
-			expected:     expectedStackTrace("new err", 16),
-		},
-	}
-	for _, v := range data {
-		t.Run(v.name, func(t *testing.T) {
-			result := fmt.Sprintf(v.formatString, se)
-			if diff := cmp.Diff(v.expected, result); diff != "" {
-				t.Errorf("stacktrace differs\n%s", diff)
-			}
-		})
-	}
-	expected := expectedStackTrace("", 16)
+	want := traceLine(15)
+	got := traceError(t, se)
 
-	actualLines, err := serrors.Trace(se, serrors.PanicFormat)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	actual := strings.Join(actualLines, "\n")
-
-	if diff := cmp.Diff(expected, actual); diff != "" {
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("stacktrace differs:\n%s", diff)
 	}
 
-	// re-wrap does nothing
 	se2 := serrors.WithStack(se)
-	for _, tt := range data {
-		t.Run(tt.name, func(t *testing.T) {
-			result := fmt.Sprintf(tt.formatString, se2)
-			if diff := cmp.Diff(tt.expected, result); diff != "" {
-				t.Errorf("stacktrace differs\n%s", diff)
-			}
-		})
+	if !errors.Is(se2, se) {
+		t.Error("wrapping is not a noop")
 	}
 }
 
@@ -84,8 +37,8 @@ func TestSentinel(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	err := serrors.New("test message")
-	expected := expectedStackTrace("test message", 86)
-	result := fmt.Sprintf("%+v", err)
+	expected := traceLine(39)
+	result := traceError(t, err)
 	if diff := cmp.Diff(expected, result); diff != "" {
 		t.Errorf("stacktrace differs\n%s", diff)
 	}
@@ -96,25 +49,29 @@ func TestErrorf(t *testing.T) {
 		name         string
 		formatString string
 		values       []interface{}
-		expected     string
+		wantMessage  string
+		wantTrace    string
 	}{
 		{
 			"wrapped non-stack trace error",
-			"This is a %s: %w",
+			"this is an %s: %w",
 			[]interface{}{"error", errors.New("inner error")},
-			expectedStackTrace("This is a error: inner error", 123),
+			"this is an error: inner error",
+			traceLine(80),
 		},
 		{
 			"wrapped stack trace error",
-			"This is a %s: %w",
+			"this is an %s: %w",
 			[]interface{}{"error", serrors.New("inner error")},
-			expectedStackTrace("This is a error: inner error", 110),
+			"this is an error: inner error",
+			traceLine(65),
 		},
 		{
 			"no error",
-			"This is a %s",
+			"this is an %s",
 			[]interface{}{"error"},
-			expectedStackTrace("This is a error", 123),
+			"this is an error",
+			traceLine(80),
 		},
 	}
 	for _, v := range data {
@@ -122,8 +79,8 @@ func TestErrorf(t *testing.T) {
 		// as the caller and not test.func1
 		errOuter := serrors.Errorf(v.formatString, v.values...)
 		t.Run(v.name, func(t *testing.T) {
-			result := fmt.Sprintf("%+v", errOuter)
-			if diff := cmp.Diff(v.expected, result); diff != "" {
+			result := traceError(t, errOuter)
+			if diff := cmp.Diff(v.wantTrace, result); diff != "" {
 				t.Errorf("stacktrace differs\n%s", diff)
 			}
 		})
@@ -158,95 +115,21 @@ func Test_stackErr_Is(t *testing.T) {
 	}
 }
 
-func TestErrorPrinting(t *testing.T) {
-	err := serrors.New("error message")
-	err2 := serrors.Errorf("wrapped %w", err)
-	data := []struct {
-		name     string
-		err      error
-		format   string
-		expected string
-	}{
-		{
-			name:     "v",
-			err:      err,
-			format:   "%v",
-			expected: `error message`,
-		},
-		{
-			name:     "plus_v",
-			err:      err,
-			format:   "%+v",
-			expected: expectedStackTrace("error message", 162),
-		},
-		{
-			name:     "s",
-			err:      err,
-			format:   "%s",
-			expected: `error message`,
-		},
-		{
-			name:     "q",
-			err:      err,
-			format:   "%q",
-			expected: `"error message"`,
-		},
-		{
-			name:     "proxy_v",
-			err:      err2,
-			format:   "%v",
-			expected: `wrapped error message`,
-		},
-		{
-			name:     "proxy_plus_v",
-			err:      err2,
-			format:   "%+v",
-			expected: expectedStackTrace("wrapped error message", 162),
-		},
-		{
-			name:     "proxy_s",
-			err:      err2,
-			format:   "%s",
-			expected: `wrapped error message`,
-		},
-		{
-			name:     "proxy_q",
-			err:      err2,
-			format:   "%q",
-			expected: `"wrapped error message"`,
-		},
-	}
-	for _, v := range data {
-		t.Run(v.name, func(t *testing.T) {
-			result := fmt.Sprintf(v.format, v.err)
-			if diff := cmp.Diff(v.expected, result); diff != "" {
-				t.Errorf("stacktrace differs\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestWithStackNil(t *testing.T) {
 	if serrors.WithStack(nil) != nil {
 		t.Error("Got non-nil for nil passed to WithStack")
 	}
 }
 
-// expectedStackTrace formats a stack trace message based on the message and provided line
-// for the test, using the actual outside callers of the test. The test has to pass in
-// the expected line number, as the error will not have occurred on the same line
-// as the call to this function.
-func expectedStackTrace(message string, expectedLine int) string {
+// traceLine formats a stack trace message based on the provided line for the
+// test, using the actual outside callers of the test.
+func traceLine(expectedLine int) string {
 	pcs := make([]uintptr, 100)
 	// start at 2, skipping runtime.Callers and this function
 	n := runtime.Callers(2, pcs)
 	frames := runtime.CallersFrames(pcs[:n])
 
 	str := strings.Builder{}
-	if message != "" {
-		fmt.Fprintln(&str, message)
-	}
-
 	frame, _ := frames.Next()
 	frame.Line = expectedLine
 	_ = serrors.PanicFormat.Execute(&str, frame)
@@ -262,4 +145,13 @@ func expectedStackTrace(message string, expectedLine int) string {
 		str.WriteByte('\n')
 	}
 	return str.String()
+}
+
+// traceError formats a stack trace from an error.
+func traceError(t *testing.T, err error) string {
+	lines, err := serrors.Trace(err, serrors.PanicFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.Join(lines, "\n")
 }

--- a/status.go
+++ b/status.go
@@ -3,7 +3,6 @@ package serrors
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -107,19 +106,6 @@ func (s statusError) Error() string {
 		return ""
 	}
 	return s.Err.Error()
-}
-
-// Format uses the underlying formatter for the error, if one exists. This
-// allows us to preserve the behavior of the underlying error if the verb
-// changes the way it is formatted.
-func (s statusError) Format(f fmt.State, verb rune) {
-	var formatter fmt.Formatter
-	if errors.As(s.Err, &formatter) {
-		formatter.Format(f, verb)
-		return
-	}
-
-	io.WriteString(f, s.Error()) // nolint: errcheck
 }
 
 // Unwrap returns the underlying error.

--- a/status_test.go
+++ b/status_test.go
@@ -69,8 +69,8 @@ func TestNewStatusErrorf_wraps_stack_tracer(t *testing.T) {
 		t.Errorf("want message %q, got %q", wantMsg, msg)
 	}
 
-	wantVerbose := expectedStackTrace("wrapping: oh no", 55)
-	got := fmt.Sprintf("%+v", err)
+	wantVerbose := traceLine(55)
+	got := traceError(t, err)
 	if diff := cmp.Diff(wantVerbose, got); diff != "" {
 		t.Errorf("results differ (-want +got):\n%s", diff)
 	}
@@ -80,9 +80,9 @@ func TestWithStatus(t *testing.T) {
 	err := serrors.New("test message")
 	err = serrors.WithStatus(200, err)
 
-	expected := expectedStackTrace("test message", 80)
-	result := fmt.Sprintf("%+v", err)
-	if diff := cmp.Diff(expected, result); diff != "" {
+	got := traceError(t, err)
+	want := traceLine(80)
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("results differ (-want +got):\n%s", diff)
 	}
 }
@@ -123,28 +123,12 @@ func TestNewFromStatus(t *testing.T) {
 				t.Errorf("want error %q, got %q", tt.wantText, err.Error())
 			}
 
-			expected := expectedStackTrace(tt.wantText, 112)
-			result := fmt.Sprintf("%+v", err)
-			if diff := cmp.Diff(expected, result); diff != "" {
+			got := traceError(t, err)
+			want := traceLine(112)
+			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("results differ (-want +got):\n%s", diff)
 			}
 		})
-	}
-}
-
-type messageError struct{}
-
-func (e messageError) Error() string {
-	return "foo"
-}
-
-func Test_statusError_Format(t *testing.T) {
-	err := serrors.WithStatus(400, messageError{})
-
-	want := "foo"
-	got := fmt.Sprintf("%s", err)
-	if want != got {
-		t.Errorf("want message %q, got %q", want, got)
 	}
 }
 


### PR DESCRIPTION
Using print formatting verbs to opt into stack trace is a smart concept, but in practice it falls short for a few reasons.

The first is that in real world scenarios, the selection of formatting verb is not done specifically with error stack traces in mind. This disconnect is most obvious in slog's handling of "any" types, including errors. When slog serializes an "any" type, the `%+v` verb is used, and stack traces are automatically included. Unfortunately this means that by default, the default slog logger and the text logger include the full stack trace as an inline value in a logfmt-style key/value pair. This is virtually never what someone would want.

The good news is, when someone explicitly wants a stack trace, there is already a mechanism by which they can get that, which is by using `errors.As` with `serrors.StackTracer`. Even though the level of effort to opt-in is a bit higher, it means slog handlers can be written to include stack traces without worrying about making the default logging behavior harder to parse.

The second is that it plays poorly with error wrapping. The original xerrors design had iteration in mind--each error after formatting itself would return the next error in the error chain. If this got adoption in the standard library, it would probably be a safe assumption that any error wrapper would be able to delegate formatting appropriately down the chain, and any error wrapper not conforming to this pattern was out of compliance, the same way that `Unwrap` support is assumed today.

Unfortunately, serrors was not originally designed to do this, and even if it were, it requires every wrapper up the stack to adhere to the same principle. Since a simple `fmt.Errorf` will swallow any custom formatting, the error printing behavior becomes unreliable based on what wrappers are in use.

Because this removes one of the three documented ways to get the stack trace out of an error, it is considered a breaking change. I would not expect it to break applications, but the change in behavior may be meaningful for application logs where stack traces may need to be explicitly opted into using one of the other two documented methods.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
