### PR TITLE
docs: deprecate sentinel errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -174,6 +174,9 @@ func Trace(e error, t *template.Template) ([]string, error) {
 
 // Sentinel is a way to turn a constant string into an error. It allows you to safely declare a
 // package-level error so that it can't be accidentally modified to refer to a different value.
+//
+// Deprecated: For package-scoped errors or other errors that should not have
+// stack traces, use the standard library's [errors.New].
 type Sentinel string
 
 // Error is the marker interface for an error. This converts a Sentinel into a string for output.


### PR DESCRIPTION
The benefit to `serrors.Sentinel` is you can't reassign it, compared to `var ErrFoo = errors.New("...")`, but the downside is that `serrors.Sentinel("not found")` is equal to every other `serrors.Sentinel("not found")` even if they are declared in separate packages. `errors.New("not found")` is only equal to itself, not other errors declared with the same message. And for the common case, where you declare a custom `ErrNotFound`, I would expect that not to match any error other than itself.

I expect neither to matter most of the time, but of the two, I would expect the `serrors.Sentinel` issue to come up more. I can't really imagine a scenario where someone reassigns a sentinel error and expects it pass code review.

The one other caveat is that we're going to be asking for people to use `errors.New` at the package scope, and `serrors.New` in other scope, which only being off by 1 letter might be confusing or easy to mess up. But I'm not sure if that's really enough of a justification to push the argument in any direction.

The Go project also had a similar discussion regarding the standard library (39493), and the consensus is best summarized by Russ Cox's comment regarding an `serrors.Sentinel` equivalent being added to the `errors` package:

> This is the semantics that errors.New used to have, before Go 1, and
> we explicitly rejected that implementation, to avoid errors defined in
> two different packages with the same text accidentally being equal. I
> don't think we want to put that bug-prone behavior back under a
> different name, nor under the same name.

When we're talking about a tradeoff that is at best roughly equal, and at worst dangerous, my inclination is to stick to the standard library.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
